### PR TITLE
Update rack-cors.gemspec

### DIFF
--- a/rack-cors.gemspec
+++ b/rack-cors.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
     'funding_uri' => 'https://github.com/sponsors/cyu'
   }
 
-  spec.add_dependency 'rack', '>= 2.0.0'
+  spec.add_dependency 'rack', '>= 3.0.14'
   spec.add_development_dependency 'bundler', '>= 1.16.0', '< 3'
   spec.add_development_dependency 'minitest', '~> 5.11.0'
   spec.add_development_dependency 'mocha', '~> 1.6.0'


### PR DESCRIPTION
Update rack gem to version 3.0.14 to address security vulnerability

- Updated the `rack` gem to version 3.0.14 or higher in the Gemfile.
- This resolves the vulnerability identified in versions of `rack` below 3.0.14.
- Ensured compatibility with `rack-cors` gem.